### PR TITLE
Add env template and memoize search handler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Database connection string used by Prisma.
+# For local development we use the SQLite database stored in the db/ directory.
+DATABASE_URL="file:./db/dev.db"
+
+# Base URL for the AI provider used by the prompt transformer endpoint.
+# Replace with your local or hosted OpenAI-compatible endpoint.
+AI_BASE_URL="https://api.openai.com/v1"
+
+# API key for the AI provider. Leave empty if your provider does not require authentication.
+AI_API_KEY="sk-your-api-key"
+
+# Default model identifier passed to the AI provider.
+AI_MODEL="gpt-4o-mini"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -98,6 +98,10 @@ export default function PromptVerse() {
   const [error, setError] = useState<string | null>(null);
   const [defaultUser, setDefaultUser] = useState<{ id: string; name: string; email: string } | null>(null);
 
+  const handleSearchChange = useCallback((query: string) => {
+    setFilters((prev) => ({ ...prev, search: query }));
+  }, []);
+
   const fetchDefaultUser = useCallback(async () => {
     try {
       const response = await fetch("/api/users?limit=1");
@@ -404,7 +408,7 @@ export default function PromptVerse() {
           <div className="ml-auto flex items-center space-x-4">
             <AdvancedSearch
               searchQuery={filters.search}
-              onSearchChange={(query) => setFilters(prev => ({ ...prev, search: query }))}
+              onSearchChange={handleSearchChange}
               prompts={filteredPrompts}
             />
             <Button size="sm" onClick={() => setIsCreateDialogOpen(true)}>


### PR DESCRIPTION
## Summary
- add a tracked `.env.example` file with sensible defaults for Prisma and the AI provider
- memoize the advanced search change handler to avoid re-render loops in the main page header

## Testing
- npm install --no-progress
- PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma migrate dev --name init *(fails: Prisma engines download is blocked with HTTP 403 in the execution environment)*
- npm run db:seed *(fails: @prisma/client is not generated because Prisma engines cannot be downloaded in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db23d755e88333a4d605d406b41058